### PR TITLE
feat: improve page responsiveness

### DIFF
--- a/src/assets/css/Register2.css
+++ b/src/assets/css/Register2.css
@@ -6,18 +6,21 @@ body {
 }
 
 .register-wrapper {
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 20px;
 }
 
 .register-box {
-  width: 400px;
+  width: 100%;
+  max-width: 400px;
   padding: 30px 40px;
   background-color: #fff;
   border-radius: 12px;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  box-sizing: border-box;
 }
 
 .register-box h2 {
@@ -164,4 +167,20 @@ body {
   font-size: 14px;
   display: block;
   margin-bottom: 12px;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .register-box {
+    padding: 20px;
+  }
+
+  .otp-group {
+    flex-direction: column;
+  }
+
+  .otp-btn {
+    width: 100%;
+    margin-top: 8px;
+  }
 }

--- a/src/assets/css/home.css
+++ b/src/assets/css/home.css
@@ -676,3 +676,58 @@ body {
 .main-content {
   flex: 1;
 }
+
+/* Responsive adjustments for HomePage */
+@media (max-width: 768px) {
+  .slider-container {
+    height: 300px;
+  }
+
+  .item_review {
+    width: 45%;
+    min-width: unset;
+    min-height: 250px;
+  }
+
+  .item_products_home {
+    width: 45%;
+    min-width: unset;
+  }
+
+  .image_poster {
+    width: 220px;
+    height: 300px;
+  }
+
+  .about-us {
+    padding: 40px 5%;
+  }
+}
+
+@media (max-width: 480px) {
+  .slider-container {
+    height: 200px;
+  }
+
+  .review_home {
+    gap: 10px;
+  }
+
+  .item_review {
+    width: 100%;
+    min-height: 200px;
+  }
+
+  .products_home {
+    justify-content: center;
+  }
+
+  .item_products_home {
+    width: 100%;
+  }
+
+  .image_poster {
+    width: 160px;
+    height: 240px;
+  }
+}

--- a/src/assets/css/login.css
+++ b/src/assets/css/login.css
@@ -6,18 +6,21 @@ body {
 }
 
 .login-wrapper {
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 20px;
 }
 
 .login-box {
-  width: 380px;
+  width: 100%;
+  max-width: 380px;
   padding: 30px 40px;
   background-color: #fff;
   border-radius: 12px;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  box-sizing: border-box;
 }
 
 .login-box h2 {
@@ -141,4 +144,11 @@ body {
 
 .forgot-password a:hover {
   text-decoration: underline;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .login-box {
+    padding: 20px;
+  }
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -18,6 +18,10 @@ header {
   position: fixed;
   z-index: 9999;
 }
+.logo_header {
+  display: flex;
+  align-items: center;
+}
 .logo_header img {
   display: flex;
   align-items: center;
@@ -226,4 +230,60 @@ footer {
 }
 .fa-user {
   font-size: 20px;
+}
+
+/* Responsive header and footer */
+@media (max-width: 768px) {
+  header {
+    flex-wrap: wrap;
+    justify-content: space-between;
+    padding: 10px 15px;
+  }
+  .logo_header {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .menu_toggle {
+    display: block;
+    cursor: pointer;
+  }
+  .navigate_header {
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding-bottom: 10px;
+    display: none;
+  }
+  .navigate_header.open {
+    display: flex;
+  }
+  .tools_header {
+    margin-top: 10px;
+    gap: 20px;
+  }
+  footer {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 20px;
+  }
+  .logo_footer {
+    margin: 0 0 20px 0;
+  }
+  .contact_footer {
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    gap: 20px;
+  }
+  .item_title_contact {
+    border-bottom: none;
+  }
+}
+
+@media (min-width: 769px) {
+  .menu_toggle {
+    display: none;
+  }
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,43 +1,23 @@
 import "../assets/css/style.css"; // File CSS riêng cho Footer
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 // Import logo
 import logoImg from "../assets/img/home/logo.png";
 
 const Footer: React.FC = () => {
-  // GHI CHÚ: Logic cho nút "Back to Top" cần được triển khai lại ở đây
-  // bằng cách sử dụng React Hooks (useEffect và useState).
+  const [showBackToTop, setShowBackToTop] = useState(false);
+
   useEffect(() => {
-    const backToTopButton = document.getElementById("backToTop");
-
     const handleScroll = () => {
-      if (backToTopButton) {
-        if (window.scrollY > 300) {
-          // Hiển thị nút khi cuộn xuống 300px
-          backToTopButton.style.display = "block";
-        } else {
-          backToTopButton.style.display = "none";
-        }
-      }
+      setShowBackToTop(window.scrollY > 300);
     };
-
-    const scrollToTop = () => {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-    };
-
     window.addEventListener("scroll", handleScroll);
-    if (backToTopButton) {
-      backToTopButton.addEventListener("click", scrollToTop);
-    }
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
-    // Dọn dẹp event listener khi component bị hủy
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-      if (backToTopButton) {
-        backToTopButton.removeEventListener("click", scrollToTop);
-      }
-    };
-  }, []); // Mảng rỗng đảm bảo useEffect chỉ chạy một lần
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
 
   return (
     <footer>
@@ -117,10 +97,11 @@ const Footer: React.FC = () => {
           </div>
         </li>
       </ul>
-      {/* Nút này giờ sẽ được điều khiển bởi logic trong useEffect */}
-      <button id="backToTop" title="Lên đầu trang" style={{ display: "none" }}>
-        <i className="fas fa-arrow-up"></i>
-      </button>
+      {showBackToTop && (
+        <button id="backToTop" title="Lên đầu trang" onClick={scrollToTop}>
+          <i className="fas fa-arrow-up"></i>
+        </button>
+      )}
     </footer>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import "../assets/css/style.css";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../stores/authStore";
 import { RoleName } from "../constants/role.constant";
@@ -43,6 +44,7 @@ const Header: React.FC = () => {
   const [isAccountMenuOpen, setAccountMenuOpen] = useState(false);
   const [openCategory, setOpenCategory] = useState<number | null>(null);
   const [searchKeyword, setSearchKeyword] = useState<string>("");
+  const [isMenuOpen, setMenuOpen] = useState(false);
 
   const accountMenuRef = useRef<HTMLDivElement>(null);
 
@@ -173,14 +175,17 @@ const Header: React.FC = () => {
   return (
     <header>
       <div className="logo_header">
-        <Link to="/" className="logo">
+        <Link to="/" className="logo" onClick={() => setMenuOpen(false)}>
           <img src={logoImg} alt="Logo" />
         </Link>
+        <div className="menu_toggle" onClick={() => setMenuOpen(!isMenuOpen)}>
+          <i className="fa-solid fa-bars icon_while"></i>
+        </div>
       </div>
 
-      <ul className="navigate_header">
+      <ul className={`navigate_header ${isMenuOpen ? "open" : ""}`}>
         <li>
-          <Link to="/" className="title_header">
+          <Link to="/" className="title_header" onClick={() => setMenuOpen(false)}>
             HOME
           </Link>
         </li>
@@ -191,14 +196,14 @@ const Header: React.FC = () => {
             onMouseEnter={() => setOpenCategory(cat.id)}
             onMouseLeave={() => setOpenCategory(null)}
           >
-            <Link to={cat.path} className="title_header">
+            <Link to={cat.path} className="title_header" onClick={() => setMenuOpen(false)}>
               {cat.name}
             </Link>
             {openCategory === cat.id && cat.subcategories.length > 0 && (
               <div className="mega_menu">
                 <div className="column">
                   {cat.subcategories.map((sub) => (
-                    <Link key={sub.id} to={sub.path}>
+                    <Link key={sub.id} to={sub.path} onClick={() => setMenuOpen(false)}>
                       {sub.name}
                     </Link>
                   ))}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -81,7 +81,7 @@ const HomePage: React.FC = () => {
   return (
     <>
       {/* <Header /> */} {/* Bỏ comment khi bạn đã tạo component Header */}
-      <div className="content">
+      <main className="content">
         <div className="slider-container">
           {/* GHI CHÚ: Slider này cần được làm lại bằng thư viện React (vd: Swiper.js) hoặc custom hook */}
           <div className="slides" id="slides">
@@ -301,7 +301,7 @@ const HomePage: React.FC = () => {
             <img src={thienNguyenImg} alt="Hành trình thiện nguyện" />
           </div>
         </section>
-      </div>
+      </main>
       {/* <Footer /> */} {/* Bỏ comment khi bạn đã tạo component Footer */}
     </>
   );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import "../assets/css/login.css";
 import http from "../api/http";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../stores/authStore";
 import { toast } from "react-toastify";
 
@@ -65,9 +65,7 @@ const LoginPage: React.FC = () => {
           </button>
 
           <div className="forgot-password">
-            <a href="index.php?controller=login&action=forgotPassword">
-              Quên mật khẩu?
-            </a>
+            <Link to="/forgot-password">Quên mật khẩu?</Link>
           </div>
         </form>
 
@@ -84,8 +82,7 @@ const LoginPage: React.FC = () => {
         </div>
 
         <div className="register-link">
-          Chưa có tài khoản?{" "}
-          <a href="index.php?controller=register&action=index">Đăng ký</a>
+          Chưa có tài khoản? <Link to="/register">Đăng ký</Link>
         </div>
       </div>
     </div>

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import "../assets/css/Register2.css";
 import http from "../api/http";
 import type { RegisterBodyType } from "../models/auth.model";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 const RegisterPage: React.FC = () => {
   const [formData, setFormData] = useState<RegisterBodyType>({
@@ -135,8 +135,7 @@ const RegisterPage: React.FC = () => {
         </form>
 
         <div className="login-link">
-          Đã có tài khoản?{" "}
-          <a href="index.php?controller=login&action=index">Đăng nhập</a>
+          Đã có tài khoản? <Link to="/login">Đăng nhập</Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make Login and Register pages mobile-friendly and update navigation links
- adjust Home page layout and add responsive CSS breakpoints
- implement responsive header and footer with mobile menu toggle and layout updates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 30 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68974a3c41308325bbf8d495af851139