### PR TITLE
fix: improve HomePage responsiveness and add image carousel

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -1,7 +1,7 @@
 .main-content-area {
   /* Đẩy nội dung xuống một khoảng bằng chiều cao của Header.
      Bạn có thể điều chỉnh giá trị 80px này cho khớp với chiều cao thực tế của Header. */
-  padding-top: 50px;
+  padding-top: 60px;
 
   /* Thêm khoảng đệm bên dưới để không bị dính vào Footer */
   padding-bottom: 40px;
@@ -9,4 +9,10 @@
   /* Giúp trang có nội dung ngắn không bị kéo footer lên cao */
   min-height: 100vh;
   background-color: #f9f9f9; /* Thêm màu nền nhẹ cho trang */
+}
+
+@media (max-width: 768px) {
+  .main-content-area {
+    padding-top: 120px;
+  }
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import "../assets/css/home.css";
 
 import banner3 from "../assets/img/home/banner3.jpg";
@@ -75,49 +75,62 @@ const formatCurrency = (amount: number) => {
 };
 
 const HomePage: React.FC = () => {
-  // GHI CHÚ: Logic cho slider và poster carousel cần được triển khai bằng React Hooks (useState, useEffect)
-  // thay vì mã JavaScript cũ đã bị xóa.
+  // --- Slider images ---
+  const sliderImages = [
+    banner3,
+    banner1,
+    banner2,
+    layout1,
+    layout2,
+    layout4,
+    layout5,
+    layout6,
+    layout7,
+    layout8,
+  ];
+
+  const [currentSlide, setCurrentSlide] = useState(0);
+
+  const handlePrevSlide = () => {
+    setCurrentSlide(
+      (prevIndex) => (prevIndex - 1 + sliderImages.length) % sliderImages.length,
+    );
+  };
+
+  const handleNextSlide = () => {
+    setCurrentSlide((prevIndex) => (prevIndex + 1) % sliderImages.length);
+  };
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrentSlide(
+        (prevIndex) => (prevIndex + 1) % sliderImages.length,
+      );
+    }, 3000);
+    return () => clearInterval(timer);
+  }, [sliderImages.length]);
 
   return (
     <>
       {/* <Header /> */} {/* Bỏ comment khi bạn đã tạo component Header */}
       <main className="content">
         <div className="slider-container">
-          {/* GHI CHÚ: Slider này cần được làm lại bằng thư viện React (vd: Swiper.js) hoặc custom hook */}
-          <div className="slides" id="slides">
-            <div className="slide">
-              <img src={banner3} alt="Banner 3" />
-            </div>
-            <div className="slide">
-              <img src={banner1} alt="Banner 1" />
-            </div>
-            <div className="slide">
-              <img src={banner2} alt="Banner 2" />
-            </div>
-            <div className="slide">
-              <img src={layout1} alt="Layout 1" />
-            </div>
-            <div className="slide">
-              <img src={layout2} alt="Layout 2" />
-            </div>
-            <div className="slide">
-              <img src={layout4} alt="Layout 4" />
-            </div>
-            <div className="slide">
-              <img src={layout5} alt="Layout 5" />
-            </div>
-            <div className="slide">
-              <img src={layout6} alt="Layout 6" />
-            </div>
-            <div className="slide">
-              <img src={layout7} alt="Layout 7" />
-            </div>
-            <div className="slide">
-              <img src={layout8} alt="Layout 8" />
-            </div>
+          <div
+            className="slides"
+            style={{ transform: `translateX(-${currentSlide * 100}%)` }}
+          >
+            {sliderImages.map((img, index) => (
+              <div className="slide" key={index}>
+                <img src={img} alt={`Banner ${index + 1}`} />
+              </div>
+            ))}
           </div>
-          <button className="arrow left">❮</button>
-          <button className="arrow right">❯</button>
+          <button className="arrow left" onClick={handlePrevSlide}>
+            ❮
+          </button>
+          <button className="arrow right" onClick={handleNextSlide}>
+            ❯
+          </button>
         </div>
 
         <div className="review_home">


### PR DESCRIPTION
## Summary
- fix header overlap on small screens by increasing main padding
- implement responsive carousel for HomePage hero images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 36 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68974e93b7d88325969c68b14fe89d2e