### PR TITLE
Improve responsive layout for header, footer and home page

### DIFF
--- a/src/assets/css/home.css
+++ b/src/assets/css/home.css
@@ -1,3 +1,7 @@
+.home-page {
+  width: 100%;
+}
+
 .review_home {
   display: flex;
   flex-wrap: wrap;
@@ -694,17 +698,32 @@ body {
     min-width: unset;
   }
 
-  .image_poster {
-    width: 220px;
-    height: 300px;
+    .image_poster {
+      width: 220px;
+      height: 300px;
+    }
+
+    .about-us {
+      padding: 40px 5%;
+    }
+
+    .poster-carousel-wrapper .btn-scroll {
+      height: 40px;
+      font-size: 20px;
+    }
+
+    .charity-banner {
+      flex-direction: column;
+    }
+
+    .charity-text,
+    .charity-image {
+      flex: 1 1 auto;
+      padding: 20px;
+    }
   }
 
-  .about-us {
-    padding: 40px 5%;
-  }
-}
-
-@media (max-width: 480px) {
+  @media (max-width: 480px) {
   .slider-container {
     height: 200px;
   }
@@ -722,12 +741,24 @@ body {
     justify-content: center;
   }
 
-  .item_products_home {
-    width: 100%;
-  }
+    .item_products_home {
+      width: 100%;
+    }
 
-  .image_poster {
-    width: 160px;
-    height: 240px;
+    .image_poster {
+      width: 160px;
+      height: 240px;
+    }
+
+    .poster-carousel-wrapper .btn-scroll {
+      display: none;
+    }
+
+    .about-content h2 {
+      font-size: 1.8rem;
+    }
+
+    .about-content p {
+      font-size: 1rem;
+    }
   }
-}

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -35,6 +35,13 @@ header {
   font-weight: bold;
 }
 
+.menu_toggle {
+  display: none;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
 /* Style tổng thể cho menu */
 .navigate_header {
   display: flex;
@@ -279,6 +286,35 @@ footer {
   }
   .item_title_contact {
     border-bottom: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .logo_header img {
+    width: 150px;
+    height: auto;
+  }
+
+  .title_header {
+    font-size: 16px;
+    padding: 10px 12px;
+  }
+
+  .tools_header {
+    gap: 15px;
+  }
+
+  footer {
+    padding: 15px;
+  }
+
+  .contact_footer {
+    gap: 10px;
+  }
+
+  .logo_footerIcon {
+    width: 150px;
+    height: auto;
   }
 }
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -98,7 +98,12 @@ const Footer: React.FC = () => {
         </li>
       </ul>
       {showBackToTop && (
-        <button id="backToTop" title="Lên đầu trang" onClick={scrollToTop}>
+        <button
+          id="backToTop"
+          title="Lên đầu trang"
+          aria-label="Back to top"
+          onClick={scrollToTop}
+        >
           <i className="fas fa-arrow-up"></i>
         </button>
       )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -67,6 +67,17 @@ const Header: React.FC = () => {
     checkAuthStatus();
   }, [checkAuthStatus]);
 
+  // Đóng menu khi chuyển từ mobile sang desktop
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 769) {
+        setMenuOpen(false);
+      }
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   // Xử lý submit form tìm kiếm
   const handleSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -178,9 +189,13 @@ const Header: React.FC = () => {
         <Link to="/" className="logo" onClick={() => setMenuOpen(false)}>
           <img src={logoImg} alt="Logo" />
         </Link>
-        <div className="menu_toggle" onClick={() => setMenuOpen(!isMenuOpen)}>
+        <button
+          className="menu_toggle"
+          onClick={() => setMenuOpen(!isMenuOpen)}
+          aria-label="Toggle navigation"
+        >
           <i className="fa-solid fa-bars icon_while"></i>
-        </div>
+        </button>
       </div>
 
       <ul className={`navigate_header ${isMenuOpen ? "open" : ""}`}>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -113,7 +113,7 @@ const HomePage: React.FC = () => {
   return (
     <>
       {/* <Header /> */} {/* Bỏ comment khi bạn đã tạo component Header */}
-      <main className="content">
+      <main className="content home-page">
         <div className="slider-container">
           <div
             className="slides"
@@ -125,10 +125,18 @@ const HomePage: React.FC = () => {
               </div>
             ))}
           </div>
-          <button className="arrow left" onClick={handlePrevSlide}>
+          <button
+            className="arrow left"
+            onClick={handlePrevSlide}
+            aria-label="Previous slide"
+          >
             ❮
           </button>
-          <button className="arrow right" onClick={handleNextSlide}>
+          <button
+            className="arrow right"
+            onClick={handleNextSlide}
+            aria-label="Next slide"
+          >
             ❯
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Add resize listener and accessible toggle button for the navigation menu
- Enhance mobile styles for header, footer and home page sections
- Provide accessible back-to-top control in the footer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: found 30 errors and 6 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897516ea09883258cdceb9adbfbcc39